### PR TITLE
Updates API to support version 1.1 of GBIF Metadata Profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>gbif-api</artifactId>
-  <version>0.40</version>
+  <version>0.41-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>GBIF Common :: API</name>
@@ -19,7 +19,7 @@
     <connection>scm:git:git@github.com:gbif/${project.artifactId}.git</connection>
     <url>https://github.com/gbif/${project.artifactId}</url>
     <developerConnection>scm:git:git@github.com:gbif/${project.artifactId}.git</developerConnection>
-    <tag>gbif-api-0.40</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/src/main/java/org/gbif/api/model/registry/Contact.java
+++ b/src/main/java/org/gbif/api/model/registry/Contact.java
@@ -106,7 +106,7 @@ public class Contact implements Address, LenientEquals<Contact> {
         URI dir = URI.create(directory);
         if (dir.isAbsolute()) {
           String dir2 = dir.toString();
-          if (!dir2.endsWith("/")) {
+          if (!dir2.endsWith("/") && !dir2.endsWith("=")) {
             dir2 = dir2 + "/";
           }
           userId.add( dir2 + id);

--- a/src/main/java/org/gbif/api/model/registry/Dataset.java
+++ b/src/main/java/org/gbif/api/model/registry/Dataset.java
@@ -285,10 +285,13 @@ public class Dataset
   }
 
   /**
-   * TODO add @NotNull when all datasets have a license applied to them
+   * Persisted in the database table.
+   *
    * @return the License applied to the dataset
+   *
+   * @see <a href="http://dev.gbif.org/issues/browse/POR-3133">POR-3133</a>
    */
-  @Nullable
+  @NotNull
   public License getLicense() {
     return license;
   }

--- a/src/main/java/org/gbif/api/model/registry/Dataset.java
+++ b/src/main/java/org/gbif/api/model/registry/Dataset.java
@@ -27,6 +27,8 @@ import org.gbif.api.vocabulary.Country;
 import org.gbif.api.vocabulary.DatasetSubtype;
 import org.gbif.api.vocabulary.DatasetType;
 import org.gbif.api.vocabulary.Language;
+import org.gbif.api.vocabulary.License;
+import org.gbif.api.vocabulary.MaintenanceUpdateFrequency;
 
 import java.net.URI;
 import java.util.Date;
@@ -42,11 +44,10 @@ import javax.validation.constraints.Size;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.codehaus.jackson.annotate.JsonIgnore;
 
 /**
- * A GBIF dataset which provides occurrence data, checklist data or metadata.
- * This Dataset class is covering all of the GBIF metadata profile, but only few properties are kept in the
+ * A GBIF dataset which provides occurrence data, checklist data, sampling event data or metadata.
+ * This Dataset class is covering all of the GBIF metadata profile v1.1, but only few properties are kept in the
  * database table:
  * <ul>
  * <li>key</li>
@@ -54,6 +55,8 @@ import org.codehaus.jackson.annotate.JsonIgnore;
  * <li>duplicateOfDatasetKey</li>
  * <li>installationKey</li>
  * <li>publishingOrganizationKey</li>
+ * <li>license</li>
+ * <li>maintenanceUpdateFrequency</li>
  * <li>external</li>
  * <li>numConstituents</li>
  * <li>type</li>
@@ -129,6 +132,8 @@ public class Dataset
   private String purpose;
   private String additionalInfo;
   private Date pubDate;
+  private MaintenanceUpdateFrequency maintenanceUpdateFrequency;
+  private License license;
 
   @Override
   public UUID getKey() {
@@ -261,6 +266,45 @@ public class Dataset
    */
   public void setPublishingOrganizationKey(UUID publishingOrganizationKey) {
     this.publishingOrganizationKey = publishingOrganizationKey;
+  }
+
+  /**
+   * Persisted in the database table.
+   *
+   * @return the frequency with which changes are made to the dataset
+   */
+  @Nullable
+  public MaintenanceUpdateFrequency getMaintenanceUpdateFrequency() {
+    return maintenanceUpdateFrequency;
+  }
+  /**
+   * Persisted in the database table.
+   */
+  public void setMaintenanceUpdateFrequency(MaintenanceUpdateFrequency maintenanceUpdateFrequency) {
+    this.maintenanceUpdateFrequency = maintenanceUpdateFrequency;
+  }
+
+  /**
+   * TODO add @NotNull when all datasets have a license applied to them
+   * @return the License applied to the dataset
+   */
+  @Nullable
+  public License getLicense() {
+    return license;
+  }
+
+  /**
+   * Persisted in the database table. Can be interpreted from EML.intellectualRights using machine readable format:
+   * <pre>
+   * {@code
+   * <intellectualRights>
+   *   <para>This work is licensed under a <ulink url="http://creativecommons.org/licenses/by/4.0/legalcode"><citetitle>Creative Commons Attribution (CC-BY) 4.0 License</citetitle></ulink>.</para>
+   * </intellectualRights>
+   * }
+   * </pre>
+   */
+  public void setLicense(License license) {
+    this.license = license;
   }
 
   /**
@@ -668,7 +712,7 @@ public class Dataset
         machineTags, tags, identifiers, comments, bibliographicCitations, curatorialUnits, taxonomicCoverages,
         geographicCoverageDescription, geographicCoverages, temporalCoverages, keywordCollections, project,
         samplingDescription, countryCoverage, collections, dataDescriptions, dataLanguage, purpose, additionalInfo,
-        pubDate);
+        pubDate, maintenanceUpdateFrequency, license);
   }
 
   @Override
@@ -721,7 +765,9 @@ public class Dataset
              && Objects.equal(this.dataLanguage, that.dataLanguage)
              && Objects.equal(this.purpose, that.purpose)
              && Objects.equal(this.additionalInfo, that.additionalInfo)
-             && Objects.equal(this.pubDate, that.pubDate);
+             && Objects.equal(this.pubDate, that.pubDate)
+             && Objects.equal(this.maintenanceUpdateFrequency, that.maintenanceUpdateFrequency)
+             && Objects.equal(this.license, that.license);
     }
     return false;
   }
@@ -745,7 +791,8 @@ public class Dataset
       .add("keywordCollections", keywordCollections).add("project", project)
       .add("samplingDescription", samplingDescription).add("countryCoverage", countryCoverage)
       .add("collections", collections).add("dataDescriptions", dataDescriptions).add("dataLanguage", dataLanguage)
-      .add("purpose", purpose).add("additionalInfo", additionalInfo).add("pubDate", pubDate).toString();
+      .add("purpose", purpose).add("additionalInfo", additionalInfo).add("pubDate", pubDate)
+      .add("maintenanceUpdateFrequency", maintenanceUpdateFrequency).add("license", license).toString();
   }
 
   /**
@@ -775,7 +822,9 @@ public class Dataset
       && Objects.equal(this.citation, other.citation)
       && Objects.equal(this.rights, other.rights)
       && Objects.equal(this.lockedForAutoUpdate, other.lockedForAutoUpdate)
-      && Objects.equal(this.deleted, other.deleted);
+      && Objects.equal(this.deleted, other.deleted)
+      && Objects.equal(this.maintenanceUpdateFrequency, other.maintenanceUpdateFrequency)
+      && Objects.equal(this.license, other.license);
   }
 
 }

--- a/src/main/java/org/gbif/api/model/registry/Dataset.java
+++ b/src/main/java/org/gbif/api/model/registry/Dataset.java
@@ -133,6 +133,7 @@ public class Dataset
   private String additionalInfo;
   private Date pubDate;
   private MaintenanceUpdateFrequency maintenanceUpdateFrequency;
+  private String maintenanceDescription;
   private License license;
 
   @Override
@@ -282,6 +283,19 @@ public class Dataset
    */
   public void setMaintenanceUpdateFrequency(MaintenanceUpdateFrequency maintenanceUpdateFrequency) {
     this.maintenanceUpdateFrequency = maintenanceUpdateFrequency;
+  }
+
+  /**
+   * A description of the maintenance frequency of this resource.
+   *
+   * @return the description of the maintenance frequency of this resource
+   */
+  public String getMaintenanceDescription() {
+    return maintenanceDescription;
+  }
+
+  public void setMaintenanceDescription(String maintenanceDescription) {
+    this.maintenanceDescription = maintenanceDescription;
   }
 
   /**
@@ -715,7 +729,7 @@ public class Dataset
         machineTags, tags, identifiers, comments, bibliographicCitations, curatorialUnits, taxonomicCoverages,
         geographicCoverageDescription, geographicCoverages, temporalCoverages, keywordCollections, project,
         samplingDescription, countryCoverage, collections, dataDescriptions, dataLanguage, purpose, additionalInfo,
-        pubDate, maintenanceUpdateFrequency, license);
+        pubDate, maintenanceUpdateFrequency, maintenanceDescription, license);
   }
 
   @Override
@@ -770,6 +784,7 @@ public class Dataset
              && Objects.equal(this.additionalInfo, that.additionalInfo)
              && Objects.equal(this.pubDate, that.pubDate)
              && Objects.equal(this.maintenanceUpdateFrequency, that.maintenanceUpdateFrequency)
+             && Objects.equal(this.maintenanceDescription, that.maintenanceDescription)
              && Objects.equal(this.license, that.license);
     }
     return false;
@@ -780,7 +795,8 @@ public class Dataset
     return Objects.toStringHelper(this)
       .add("key", key).add("doi", doi).add("parentDatasetKey", parentDatasetKey)
       .add("duplicateOfDatasetKey", duplicateOfDatasetKey).add("installationKey", installationKey)
-      .add("publishingOrganizationKey", publishingOrganizationKey).add("numConstituents", numConstituents).add("type", type)
+      .add("publishingOrganizationKey", publishingOrganizationKey).add("numConstituents", numConstituents).add("type",
+        type)
       .add("subtype", subtype).add("title", title).add("alias", alias).add("abbreviation", abbreviation)
       .add("description", description).add("language", language).add("homepage", homepage).add("logoUrl", logoUrl)
       .add("citation", citation).add("rights", rights).add("lockedForAutoUpdate", lockedForAutoUpdate)
@@ -795,7 +811,8 @@ public class Dataset
       .add("samplingDescription", samplingDescription).add("countryCoverage", countryCoverage)
       .add("collections", collections).add("dataDescriptions", dataDescriptions).add("dataLanguage", dataLanguage)
       .add("purpose", purpose).add("additionalInfo", additionalInfo).add("pubDate", pubDate)
-      .add("maintenanceUpdateFrequency", maintenanceUpdateFrequency).add("license", license).toString();
+      .add("maintenanceUpdateFrequency", maintenanceUpdateFrequency)
+      .add("maintenanceDescription", maintenanceDescription).add("license", license).toString();
   }
 
   /**
@@ -827,7 +844,7 @@ public class Dataset
       && Objects.equal(this.lockedForAutoUpdate, other.lockedForAutoUpdate)
       && Objects.equal(this.deleted, other.deleted)
       && Objects.equal(this.maintenanceUpdateFrequency, other.maintenanceUpdateFrequency)
+      && Objects.equal(this.maintenanceDescription, other.maintenanceDescription)
       && Objects.equal(this.license, other.license);
   }
-
 }

--- a/src/main/java/org/gbif/api/model/registry/Dataset.java
+++ b/src/main/java/org/gbif/api/model/registry/Dataset.java
@@ -300,12 +300,17 @@ public class Dataset
 
   /**
    * Persisted in the database table.
+   * </br>
+   * Note for backwards compatibility, we cannot apply @NotNull to license. Otherwise existing users of our API
+   * would have to ensure Dataset objects always populate license.
+   * </br>
+   * In the Registry DB, Dataset.license defaults to CC-BY 4.0. Therefore license must be excluded from lenientEquals
+   * method.
    *
    * @return the License applied to the dataset
    *
    * @see <a href="http://dev.gbif.org/issues/browse/POR-3133">POR-3133</a>
    */
-  @NotNull
   public License getLicense() {
     return license;
   }
@@ -816,7 +821,7 @@ public class Dataset
   }
 
   /**
-   * Only checks the persisted properties, excluding the server controlled fields (key, created etc).
+   * Only checks the persisted properties, excluding the server controlled fields (key, created, license etc).
    * Does not include the nested properties.
    */
   @Override
@@ -844,7 +849,6 @@ public class Dataset
       && Objects.equal(this.lockedForAutoUpdate, other.lockedForAutoUpdate)
       && Objects.equal(this.deleted, other.deleted)
       && Objects.equal(this.maintenanceUpdateFrequency, other.maintenanceUpdateFrequency)
-      && Objects.equal(this.maintenanceDescription, other.maintenanceDescription)
-      && Objects.equal(this.license, other.license);
+      && Objects.equal(this.maintenanceDescription, other.maintenanceDescription);
   }
 }

--- a/src/main/java/org/gbif/api/model/registry/eml/Project.java
+++ b/src/main/java/org/gbif/api/model/registry/eml/Project.java
@@ -21,17 +21,22 @@ import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Objects;
 
 
 /**
- * A dataset can be part of a project.
+ * A dataset can be part of a project. A project can have a unique identifier, used to link datasets associated with
+ * the same project.
  */
 public class Project implements Serializable {
 
   private static final long serialVersionUID = -2625204169061362016L;
 
   private String title;
+  // TODO: enable searching datasets by their project identifier: http://dev.gbif.org/issues/browse/POR-3129
+  private String identifier;
   private String description;
 
   private List<Contact> contacts;
@@ -43,9 +48,10 @@ public class Project implements Serializable {
   }
 
   public Project(
-    String title, List<Contact> contacts, String funding, String studyAreaDescription, String designDescription
-  ) {
+    String title, String identifier, List<Contact> contacts, String funding, String studyAreaDescription,
+    String designDescription) {
     this.title = title;
+    this.identifier = identifier;
     this.contacts = contacts;
     this.funding = funding;
     this.studyAreaDescription = studyAreaDescription;
@@ -92,6 +98,20 @@ public class Project implements Serializable {
     this.title = title;
   }
 
+  /**
+   * A unique identifier for the project. Used to link multiple datasets associated with the same project.
+   *
+   * @return the unique identifier for the project
+   */
+  @Nullable
+  public String getIdentifier() {
+    return identifier;
+  }
+
+  public void setIdentifier(String identifier) {
+    this.identifier = identifier;
+  }
+
   public String getDescription() {
     return description;
   }
@@ -121,6 +141,7 @@ public class Project implements Serializable {
 
     Project that = (Project) obj;
     return Objects.equal(this.title, that.title)
+           && Objects.equal(this.identifier, that.identifier)
            && Objects.equal(this.description, that.description)
            && Objects.equal(this.contacts, that.contacts)
            && Objects.equal(this.funding, that.funding)
@@ -130,13 +151,14 @@ public class Project implements Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(title, contacts, funding, studyAreaDescription, designDescription);
+    return Objects.hashCode(title, identifier, contacts, funding, studyAreaDescription, designDescription);
   }
 
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
       .add("title", title)
+      .add("identifier", identifier)
       .add("description", description)
       .add("contacts", contacts)
       .add("funding", funding)

--- a/src/main/java/org/gbif/api/vocabulary/ContactType.java
+++ b/src/main/java/org/gbif/api/vocabulary/ContactType.java
@@ -17,8 +17,6 @@ package org.gbif.api.vocabulary;
 
 import org.gbif.api.util.VocabularyUtils;
 
-import java.util.HashMap;
-import java.util.Map;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableMap;
@@ -28,34 +26,114 @@ import com.google.common.collect.ImmutableMap;
  * A utility to infer types is provided which has historically been used during data migration activities from legacy
  * systems such as the previous "GBRDS" which was built on MySQL.
  *
- * @see <a href="http://rs.gbif.org/vocabulary/gbif/agent_role.xml">The IPT vocabulary</a>
+ * @see <a href="http://rs.gbif.org/vocabulary/gbif/agent_role.xml">rs.gbif.org vocabulary</a>
  */
 public enum ContactType {
-
+  /**
+   * A contact to contact for further technical information related to the dataset.
+   */
   TECHNICAL_POINT_OF_CONTACT,
+  /**
+   * A contact to contact for further non-technical information related to the dataset.
+   */
   ADMINISTRATIVE_POINT_OF_CONTACT,
+  /**
+   * A contact to contact for further information about the dataset.
+   */
   POINT_OF_CONTACT,
+  /**
+   * A contact who originally gathered/prepared the dataset.
+   */
   ORIGINATOR,
+  /**
+   * A contact responsible for providing the metadata.
+   */
   METADATA_AUTHOR,
+  /**
+   * A primary scientific contact associated with the dataset.
+   */
   PRINCIPAL_INVESTIGATOR,
+  /**
+   * A contact who is an author of a publication that used the dataset, or author of a data paper.
+   */
   AUTHOR,
+  /**
+   * A contact who contributed content to a dataset (the dataset being described may be a composite).
+   */
   CONTENT_PROVIDER,
+  /**
+   * A contact who is responsible for/takes care of the dataset.
+   */
   CUSTODIAN_STEWARD,
+  /**
+   * A contact involved in the publishing/distribution chain of a dataset.
+   */
   DISTRIBUTOR,
+  /**
+   * A contact associated with editing a publication that used the dataset, or a data paper.
+   */
   EDITOR,
+  /**
+   * A contact who owns the dataset (may or may not be the custodian).
+   */
   OWNER,
+  /**
+   * A contact responsible for any post-collection processing of the dataset.
+   */
   PROCESSOR,
+  /**
+   * A contact associated with the publishing of some entity (paper, article, book, etc) based on the dataset, or of a
+   * data paper.
+   */
   PUBLISHER,
+  /**
+   * The contact that makes use of the dataset.
+   */
   USER,
+  /**
+   * The contact providing informatics/programming support related to the dataset.
+   */
   PROGRAMMER,
+  /**
+   * The contact that maintains and documents the specimens in a collection. Some of their duties include preparing and
+   * labeling specimens so they are ready for identification, and protecting the specimens.
+   */
+  CURATOR,
+  /**
+   * A contact who manages the operation of a data system.
+   */
   DATA_ADMINISTRATOR,
+  /**
+   * A contact who manages the operation of a computer system.
+   */
   SYSTEM_ADMINISTRATOR,
+  /**
+   * A contact appointed to lead and represent a Participant's delegation at the GBIF Governing Board.
+   */
   HEAD_OF_DELEGATION,
+  /**
+   * A contact temporarily appointed to lead and represent a Participant's delegation at the GBIF Governing Board.
+   */
   TEMPORARY_HEAD_OF_DELEGATION,
+  /**
+   * A contact appointed to a Participant's delegation at the GBIF Governing Board.
+   */
   ADDITIONAL_DELEGATE,
+  /**
+   * A contact temporarily appointed to a Participant's delegation at the GBIF Governing Board.
+   */
   TEMPORARY_DELEGATE,
+  /**
+   * A contact representing a regional group of Nodes.
+   */
   REGIONAL_NODE_REPRESENTATIVE,
+  /**
+   * A contact leading the work of the Node and representing the Node in the Nodes Committee.
+   */
   NODE_MANAGER,
+  /**
+   * A contact who is a member of the Node's staff.
+   */
   NODE_STAFF;
 
   /**
@@ -83,6 +161,7 @@ public enum ContactType {
     .put("publisher", PUBLISHER)
     .put("user", USER)
     .put("programmer", PROGRAMMER)
+    .put("curator", CURATOR)
     .put("data administrator", DATA_ADMINISTRATOR)
     .put("system adminsitrator", SYSTEM_ADMINISTRATOR) // deliberate typo
     .put("system administrator", SYSTEM_ADMINISTRATOR)

--- a/src/main/java/org/gbif/api/vocabulary/License.java
+++ b/src/main/java/org/gbif/api/vocabulary/License.java
@@ -58,13 +58,12 @@ public enum License {
    */
   public static Optional<License> fromLicenseUrl(String licenseUrl) {
     if (!Strings.isNullOrEmpty(licenseUrl)) {
-      licenseUrl = licenseUrl.trim();
-      if (licenseUrl.endsWith("/")) {
-        licenseUrl = StringUtils.removeEnd(licenseUrl, "/");
-      }
+      licenseUrl = licenseUrl.trim().toLowerCase();
+      licenseUrl = StringUtils.removeEnd(licenseUrl, "/");
+
       // do lookup by legal code URL or human readable summary URL (excluding "/legalcode")
       for (License license : License.values()) {
-        if (license.getLicenseUrl() != null && (licenseUrl.equalsIgnoreCase(license.getLicenseUrl())
+        if (license.getLicenseUrl() != null && (licenseUrl.equals(license.getLicenseUrl())
             || license.getLicenseUrl().startsWith(licenseUrl))) {
           return Optional.fromNullable(license);
         }
@@ -75,7 +74,13 @@ public enum License {
 
   License(@Nullable String licenseTitle, @Nullable String licenseUrl) {
     this.licenseTitle = licenseTitle;
-    this.licenseUrl = licenseUrl;
+    // ensure license information is kept in lowercase internally
+    if(licenseUrl != null){
+      this.licenseUrl = licenseUrl.toLowerCase();
+    }
+    else{
+      this.licenseUrl = null;
+    }
   }
 
   /**

--- a/src/main/java/org/gbif/api/vocabulary/License.java
+++ b/src/main/java/org/gbif/api/vocabulary/License.java
@@ -1,5 +1,8 @@
 package org.gbif.api.vocabulary;
 
+import javax.annotation.Nullable;
+
+import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import org.apache.commons.lang3.StringUtils;
 
@@ -32,7 +35,15 @@ public enum License {
    *
    * @see <a href="http://creativecommons.org/licenses/by-nc/4.0/legalcode">legal document</a>
    */
-  CC_BY_NC_4_0("Creative Commons Attribution Non Commercial (CC-BY-NC) 4.0", "http://creativecommons.org/licenses/by-nc/4.0/legalcode");
+  CC_BY_NC_4_0("Creative Commons Attribution Non Commercial (CC-BY-NC) 4.0", "http://creativecommons.org/licenses/by-nc/4.0/legalcode"),
+  /**
+   * No license has been specified.
+   */
+  UNSPECIFIED(null, null),
+  /**
+   * A license not supported by GBIF.
+   */
+  UNSUPPORTED(null, null);
 
 
   private final String licenseTitle;
@@ -43,27 +54,26 @@ public enum License {
    *
    * @param licenseUrl the case insensitive URL for the license.
    *
-   * @return the matching License or null
+   * @return instance of com.google.common.base.Optional, never null
    */
-  public static License fromLicenseUrl(String licenseUrl) {
+  public static Optional<License> fromLicenseUrl(String licenseUrl) {
     if (!Strings.isNullOrEmpty(licenseUrl)) {
-      // trim URL, and remove trailing forward slash ("/")
       licenseUrl = licenseUrl.trim();
       if (licenseUrl.endsWith("/")) {
         licenseUrl = StringUtils.removeEnd(licenseUrl, "/");
       }
       // do lookup by legal code URL or human readable summary URL (excluding "/legalcode")
       for (License license : License.values()) {
-        if (licenseUrl.equalsIgnoreCase(license.getLicenseUrl())
-            || license.getLicenseUrl().startsWith(licenseUrl)) {
-          return license;
+        if (license.getLicenseUrl() != null && (licenseUrl.equalsIgnoreCase(license.getLicenseUrl())
+            || license.getLicenseUrl().startsWith(licenseUrl))) {
+          return Optional.fromNullable(license);
         }
       }
     }
-    return null;
+    return Optional.absent();
   }
 
-  License(String licenseTitle, String licenseUrl) {
+  License(@Nullable String licenseTitle, @Nullable String licenseUrl) {
     this.licenseTitle = licenseTitle;
     this.licenseUrl = licenseUrl;
   }

--- a/src/main/java/org/gbif/api/vocabulary/License.java
+++ b/src/main/java/org/gbif/api/vocabulary/License.java
@@ -1,0 +1,84 @@
+package org.gbif.api.vocabulary;
+
+import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Enumeration of the set of licenses GBIF supports for applying to a dataset. The license provides a standardised way
+ * to define appropriate uses of a dataset.
+ * </br>
+ * GBIF's recommended best practice is to use the most recent license version, which for CC-BY and CC-BY-NC is 4.0.
+ * This is in line with the recommendation from Creative Commons.
+ *
+ * @see <a href="https://creativecommons.org/faq/#why-should-i-use-the-latest-version-of-the-creative-commons-licenses">Creative Commons recommendation</a>
+ * @see <a href="http://www.gbif.org/terms/licences">GBIF Licensing</a>
+ */
+public enum License {
+
+  /**
+   * Creative Commons Zero / Public Domain version 1.0. Technically a waiver, not a license.
+   *
+   * @see <a href="http://creativecommons.org/publicdomain/zero/1.0/legalcode">legal document</a>
+   */
+  CC0_1_0("Public Domain (CC0 1.0)", "http://creativecommons.org/publicdomain/zero/1.0/legalcode"),
+  /**
+   * Creative Commons Attribution version 4.0.
+   *
+   * @see <a href="http://creativecommons.org/licenses/by/4.0/legalcode">legal document</a>
+   */
+  CC_BY_4_0("Creative Commons Attribution (CC-BY) 4.0", "http://creativecommons.org/licenses/by/4.0/legalcode"),
+  /**
+   * Creative Commons Attribution-NonCommercial version 4.0.
+   *
+   * @see <a href="http://creativecommons.org/licenses/by-nc/4.0/legalcode">legal document</a>
+   */
+  CC_BY_NC_4_0("Creative Commons Attribution Non Commercial (CC-BY-NC) 4.0", "http://creativecommons.org/licenses/by-nc/4.0/legalcode");
+
+
+  private final String licenseTitle;
+  private final String licenseUrl;
+
+  /**
+   * Lookup a License by either its a) legal code URL or b) human readable summary URL.
+   *
+   * @param licenseUrl the case insensitive URL for the license.
+   *
+   * @return the matching License or null
+   */
+  public static License fromLicenseUrl(String licenseUrl) {
+    if (!Strings.isNullOrEmpty(licenseUrl)) {
+      // trim URL, and remove trailing forward slash ("/")
+      licenseUrl = licenseUrl.trim();
+      if (licenseUrl.endsWith("/")) {
+        licenseUrl = StringUtils.removeEnd(licenseUrl, "/");
+      }
+      // do lookup by legal code URL or human readable summary URL (excluding "/legalcode")
+      for (License license : License.values()) {
+        if (licenseUrl.equalsIgnoreCase(license.getLicenseUrl())
+            || license.getLicenseUrl().startsWith(licenseUrl)) {
+          return license;
+        }
+      }
+    }
+    return null;
+  }
+
+  License(String licenseTitle, String licenseUrl) {
+    this.licenseTitle = licenseTitle;
+    this.licenseUrl = licenseUrl;
+  }
+
+  /**
+   * @return the License URL
+   */
+  public String getLicenseUrl() {
+    return licenseUrl;
+  }
+
+  /**
+   * @return the License title
+   */
+  public String getLicenseTitle() {
+    return licenseTitle;
+  }
+}

--- a/src/main/java/org/gbif/api/vocabulary/MaintenanceUpdateFrequency.java
+++ b/src/main/java/org/gbif/api/vocabulary/MaintenanceUpdateFrequency.java
@@ -1,0 +1,65 @@
+package org.gbif.api.vocabulary;
+
+import org.gbif.api.util.VocabularyUtils;
+
+/**
+ * Enumeration for describing the frequency with which changes and additions are made to the dataset after the initial
+ * dataset is completed. Based on the EML v2.1.1 MaintUpFreqType enumeration.
+ *
+ * @see <a href="http://rs.gbif.org/vocabulary/eml/update_frequency.xml">rs.gbif.org vocabulary</a>
+ * @see <a href="https://knb.ecoinformatics.org/#external//emlparser/docs/eml-2.1.1/./eml-dataset.html#MaintUpFreqType">EML
+ * Enumeration</a>
+ */
+public enum MaintenanceUpdateFrequency {
+  /**
+   * Updated 1 time each day.
+   */
+  DAILY,
+  /**
+   * Updated 1 time each week.
+   */
+  WEEKLY,
+  /**
+   * Updated 1 time each month.
+   */
+  MONTHLY,
+  /**
+   * Updated 2 times each year.
+   */
+  BIANNUALLY,
+  /**
+   * Updated 1 time each year.
+   */
+  ANNUALLY,
+  /**
+   * Updated as needed.
+   */
+  AS_NEEDED,
+  /**
+   * Updated continually.
+   */
+  CONTINUALLY,
+  /**
+   * Updated at irregular intervals.
+   */
+  IRREGULAR,
+  /**
+   * Further updates are not planned.
+   */
+  NOT_PLANNED,
+  /**
+   * Further updates may still happen, but it is not known for sure. Note: typo matches EML enumeration.
+   */
+  UNKOWN,
+  /**
+   * Updated according to some other interval.
+   */
+  OTHER_MAINTENANCE_PERIOD;
+
+  /**
+   * @return the matching MaintenanceUpdateFrequency or null
+   */
+  public static MaintenanceUpdateFrequency fromString(String frequency) {
+    return (MaintenanceUpdateFrequency) VocabularyUtils.lookupEnum(frequency, MaintenanceUpdateFrequency.class);
+  }
+}

--- a/src/test/java/org/gbif/api/model/registry/ContactTest.java
+++ b/src/test/java/org/gbif/api/model/registry/ContactTest.java
@@ -31,5 +31,14 @@ public class ContactTest {
 
     c.addUserId("http://orcid.org", "de/12-3421423");
     assertEquals("http://orcid.org/de/12-3421423", c.getUserId().get(5));
+
+    c.addUserId("https://scholar.google.com/citations?user=", "jvW0IrIAAAAJ");
+    assertEquals("https://scholar.google.com/citations?user=jvW0IrIAAAAJ", c.getUserId().get(6));
+
+    c.addUserId("https://www.linkedin.com/in/", "john-smith-12345");
+    assertEquals("https://www.linkedin.com/in/john-smith-12345", c.getUserId().get(7));
+
+    c.addUserId("https://www.linkedin.com/profile/view?id=", "AAkAAABiOnwBeoX3a3wKqe4IEqDkJ_ifoVj1234");
+    assertEquals("https://www.linkedin.com/profile/view?id=AAkAAABiOnwBeoX3a3wKqe4IEqDkJ_ifoVj1234", c.getUserId().get(8));
   }
 }

--- a/src/test/java/org/gbif/api/model/registry/DatasetTest.java
+++ b/src/test/java/org/gbif/api/model/registry/DatasetTest.java
@@ -72,11 +72,13 @@ public class DatasetTest {
   public void testLenientEquals() {
     Dataset ds1 = new Dataset();
     ds1.setMaintenanceUpdateFrequency(MaintenanceUpdateFrequency.DAILY);
+    ds1.setMaintenanceDescription("Daily, except for holidays");
     ds1.setLicense(License.CC_BY_4_0);
     ds1.setCreated(new Date());
 
     Dataset ds2 = new Dataset();
     ds2.setMaintenanceUpdateFrequency(MaintenanceUpdateFrequency.DAILY);
+    ds2.setMaintenanceDescription("Daily, except for holidays");
     ds2.setLicense(License.CC_BY_4_0);
     ds1.setCreated(new Date()); // different created date!
 

--- a/src/test/java/org/gbif/api/model/registry/DatasetTest.java
+++ b/src/test/java/org/gbif/api/model/registry/DatasetTest.java
@@ -44,10 +44,10 @@ public class DatasetTest {
     Set<ConstraintViolation<Dataset>> violations = validator.validate(ds);
     assertTrue("Violations were expected", !violations.isEmpty());
 
-    // ensure all 7 expected violations are caught
+    // ensure all 6 expected violations are caught
     Set<String> propertiesInViolation =
-      Sets.newHashSet("title", "homepage", "logoUrl", "type", "installationKey", "publishingOrganisationKey", "license");
-    assertEquals(7, violations.size());
+      Sets.newHashSet("title", "homepage", "logoUrl", "type", "installationKey", "publishingOrganisationKey");
+    assertEquals(6, violations.size());
     for (ConstraintViolation<?> cv : violations) {
       propertiesInViolation.contains(cv.getPropertyPath().toString());
     }
@@ -61,7 +61,6 @@ public class DatasetTest {
     ds.setType(DatasetType.SAMPLING_EVENT);
     ds.setInstallationKey(UUID.randomUUID());
     ds.setPublishingOrganizationKey(UUID.randomUUID());
-    ds.setLicense(License.CC_BY_NC_4_0);
 
     // perform validation again
     violations = validator.validate(ds);
@@ -79,7 +78,7 @@ public class DatasetTest {
     Dataset ds2 = new Dataset();
     ds2.setMaintenanceUpdateFrequency(MaintenanceUpdateFrequency.DAILY);
     ds2.setMaintenanceDescription("Daily, except for holidays");
-    ds2.setLicense(License.CC_BY_4_0);
+    ds2.setLicense(License.CC0_1_0); // different license
     ds1.setCreated(new Date()); // different created date!
 
     assertTrue(ds1.lenientEquals(ds2)); // true because lenient equals excludes

--- a/src/test/java/org/gbif/api/model/registry/DatasetTest.java
+++ b/src/test/java/org/gbif/api/model/registry/DatasetTest.java
@@ -1,0 +1,84 @@
+package org.gbif.api.model.registry;
+
+import org.gbif.api.vocabulary.DatasetType;
+import org.gbif.api.vocabulary.License;
+import org.gbif.api.vocabulary.MaintenanceUpdateFrequency;
+
+import java.net.URI;
+import java.util.Date;
+import java.util.Set;
+import java.util.UUID;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import com.google.common.collect.Sets;
+import org.apache.bval.jsr303.ApacheValidationProvider;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DatasetTest {
+
+  @Test
+  public void testValidations() {
+    ValidatorFactory validatorFactory =
+      Validation.byProvider(ApacheValidationProvider.class).configure().buildValidatorFactory();
+    Validator validator = validatorFactory.getValidator();
+
+    Dataset ds = new Dataset();
+
+    // 3 non-mandatory fields that don't validate
+    ds.setTitle("B"); // too short
+    ds.setHomepage(URI.create("www.gbif.org")); // doesn't start with http or https
+    ds.setLogoUrl(URI.create("file:///tmp/aha")); // bad http URI
+
+    // All mandatory fields missing include:
+    // ds.setType(?);
+    // ds.setInstallationKey(?);
+    // ds.setPublishingOrganizationKey(?);
+
+    // perform validation
+    Set<ConstraintViolation<Dataset>> violations = validator.validate(ds);
+    assertTrue("Violations were expected", !violations.isEmpty());
+
+    // ensure all 6 expected violations are caught
+    Set<String> propertiesInViolation =
+      Sets.newHashSet("title", "homepage", "logoUrl", "type", "installationKey", "publishingOrganisationKey");
+    assertEquals(6, violations.size());
+    for (ConstraintViolation<?> cv : violations) {
+      propertiesInViolation.contains(cv.getPropertyPath().toString());
+    }
+
+    // fix non-mandatory fields that don't validate
+    ds.setTitle("Rooftop bugs");
+    ds.setHomepage(URI.create("http://www.gbif.org"));
+    ds.setLogoUrl(URI.create("http://www.gbif.org/logo.png"));
+
+    // add all mandatory fields that were missing
+    ds.setType(DatasetType.SAMPLING_EVENT);
+    ds.setInstallationKey(UUID.randomUUID());
+    ds.setPublishingOrganizationKey(UUID.randomUUID());
+
+    // perform validation again
+    violations = validator.validate(ds);
+    assertTrue("No violations were expected", violations.isEmpty());
+  }
+
+  @Test
+  public void testLenientEquals() {
+    Dataset ds1 = new Dataset();
+    ds1.setMaintenanceUpdateFrequency(MaintenanceUpdateFrequency.DAILY);
+    ds1.setLicense(License.CC_BY_4_0);
+    ds1.setCreated(new Date());
+
+    Dataset ds2 = new Dataset();
+    ds2.setMaintenanceUpdateFrequency(MaintenanceUpdateFrequency.DAILY);
+    ds2.setLicense(License.CC_BY_4_0);
+    ds1.setCreated(new Date()); // different created date!
+
+    assertTrue(ds1.lenientEquals(ds2)); // true because lenient equals excludes
+  }
+}

--- a/src/test/java/org/gbif/api/model/registry/DatasetTest.java
+++ b/src/test/java/org/gbif/api/model/registry/DatasetTest.java
@@ -44,10 +44,10 @@ public class DatasetTest {
     Set<ConstraintViolation<Dataset>> violations = validator.validate(ds);
     assertTrue("Violations were expected", !violations.isEmpty());
 
-    // ensure all 6 expected violations are caught
+    // ensure all 7 expected violations are caught
     Set<String> propertiesInViolation =
-      Sets.newHashSet("title", "homepage", "logoUrl", "type", "installationKey", "publishingOrganisationKey");
-    assertEquals(6, violations.size());
+      Sets.newHashSet("title", "homepage", "logoUrl", "type", "installationKey", "publishingOrganisationKey", "license");
+    assertEquals(7, violations.size());
     for (ConstraintViolation<?> cv : violations) {
       propertiesInViolation.contains(cv.getPropertyPath().toString());
     }
@@ -61,6 +61,7 @@ public class DatasetTest {
     ds.setType(DatasetType.SAMPLING_EVENT);
     ds.setInstallationKey(UUID.randomUUID());
     ds.setPublishingOrganizationKey(UUID.randomUUID());
+    ds.setLicense(License.CC_BY_NC_4_0);
 
     // perform validation again
     violations = validator.validate(ds);

--- a/src/test/java/org/gbif/api/model/registry/eml/ProjectTest.java
+++ b/src/test/java/org/gbif/api/model/registry/eml/ProjectTest.java
@@ -1,0 +1,26 @@
+package org.gbif.api.model.registry.eml;
+
+
+import org.gbif.api.model.registry.Contact;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotEquals;
+
+public class ProjectTest {
+
+  @Test
+  public void testEquals() {
+    Project p1 = new Project("BioFresh Project", "226874", Lists.newArrayList(new Contact()),
+      "Funded by the EU under the 7th Framework Programme", "Ran from November 2009 until April 2014.",
+      "Established an internet platform bringing together information and data on freshwater biodiversity.");
+
+    // identifier is null
+    Project p2 = new Project("BioFresh Project", null, Lists.newArrayList(new Contact()),
+      "Funded by the EU under the 7th Framework Programme", "Ran from November 2009 until April 2014.",
+      "Established an internet platform bringing together information and data on freshwater biodiversity.");
+
+    assertNotEquals(p1, p2);
+  }
+}

--- a/src/test/java/org/gbif/api/vocabulary/ContactTypeTest.java
+++ b/src/test/java/org/gbif/api/vocabulary/ContactTypeTest.java
@@ -13,6 +13,7 @@ public class ContactTypeTest {
     assertEquals(ContactType.POINT_OF_CONTACT, ContactType.fromString("point_of_contact"));
     assertEquals(ContactType.POINT_OF_CONTACT, ContactType.fromString("pointOfContact"));
     assertEquals(ContactType.POINT_OF_CONTACT, ContactType.fromString("pointofcontact"));
+    assertEquals(ContactType.CURATOR, ContactType.fromString("curator"));
   }
 
 }

--- a/src/test/java/org/gbif/api/vocabulary/LicenseTest.java
+++ b/src/test/java/org/gbif/api/vocabulary/LicenseTest.java
@@ -11,19 +11,19 @@ public class LicenseTest {
   @Test
   public void testFromString() throws Exception {
     // positive matches
-    assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0/legalcode"));
-    assertEquals(License.CC0_1_0, License.fromLicenseUrl(" http://creativecommons.org/publicdomain/zero/1.0/legalcode "));
-    assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0/legalcode/"));
-    assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0"));
-    assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0/"));
-    assertEquals(License.CC_BY_4_0, License.fromLicenseUrl("http://creativecommons.org/licenses/by/4.0/legalcode"));
+    assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0/legalcode").get());
+    assertEquals(License.CC0_1_0, License.fromLicenseUrl(" http://creativecommons.org/publicdomain/zero/1.0/legalcode ").get());
+    assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0/legalcode/").get());
+    assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0").get());
+    assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0/").get());
+    assertEquals(License.CC_BY_4_0, License.fromLicenseUrl("http://creativecommons.org/licenses/by/4.0/legalcode").get());
     assertEquals(License.CC_BY_NC_4_0,
-      License.fromLicenseUrl("http://creativecommons.org/licenses/by-nc/4.0/legalcode"));
+      License.fromLicenseUrl("http://creativecommons.org/licenses/by-nc/4.0/legalcode").get());
     // negative matches
-    assertNull(License.fromLicenseUrl("CC0"));
-    assertNull(License.fromLicenseUrl("https://creativecommons.org/licenses/by/3.0/legalcode"));
-    assertNull(License.fromLicenseUrl("https://creativecommons.org/licenses/by/3.0/"));
-    assertNull(License.fromLicenseUrl("https://creativecommons.org/licenses/by-nc/2.0/legalcode"));
-    assertNull(License.fromLicenseUrl("https://creativecommons.org/licenses/by-nc/2.0/"));
+    assertNull(License.fromLicenseUrl("CC0").orNull());
+    assertNull(License.fromLicenseUrl("https://creativecommons.org/licenses/by/3.0/legalcode").orNull());
+    assertNull(License.fromLicenseUrl("https://creativecommons.org/licenses/by/3.0/").orNull());
+    assertNull(License.fromLicenseUrl("https://creativecommons.org/licenses/by-nc/2.0/legalcode").orNull());
+    assertNull(License.fromLicenseUrl("https://creativecommons.org/licenses/by-nc/2.0/").orNull());
   }
 }

--- a/src/test/java/org/gbif/api/vocabulary/LicenseTest.java
+++ b/src/test/java/org/gbif/api/vocabulary/LicenseTest.java
@@ -12,6 +12,7 @@ public class LicenseTest {
   public void testFromString() throws Exception {
     // positive matches
     assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0/legalcode").get());
+    assertEquals(License.CC0_1_0, License.fromLicenseUrl("HTTP://creativecommons.org/publicdomain/zero/1.0/legalcode").get());
     assertEquals(License.CC0_1_0, License.fromLicenseUrl(" http://creativecommons.org/publicdomain/zero/1.0/legalcode ").get());
     assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0/legalcode/").get());
     assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0").get());

--- a/src/test/java/org/gbif/api/vocabulary/LicenseTest.java
+++ b/src/test/java/org/gbif/api/vocabulary/LicenseTest.java
@@ -1,0 +1,29 @@
+package org.gbif.api.vocabulary;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class LicenseTest {
+
+  @Test
+  public void testFromString() throws Exception {
+    // positive matches
+    assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0/legalcode"));
+    assertEquals(License.CC0_1_0, License.fromLicenseUrl(" http://creativecommons.org/publicdomain/zero/1.0/legalcode "));
+    assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0/legalcode/"));
+    assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0"));
+    assertEquals(License.CC0_1_0, License.fromLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0/"));
+    assertEquals(License.CC_BY_4_0, License.fromLicenseUrl("http://creativecommons.org/licenses/by/4.0/legalcode"));
+    assertEquals(License.CC_BY_NC_4_0,
+      License.fromLicenseUrl("http://creativecommons.org/licenses/by-nc/4.0/legalcode"));
+    // negative matches
+    assertNull(License.fromLicenseUrl("CC0"));
+    assertNull(License.fromLicenseUrl("https://creativecommons.org/licenses/by/3.0/legalcode"));
+    assertNull(License.fromLicenseUrl("https://creativecommons.org/licenses/by/3.0/"));
+    assertNull(License.fromLicenseUrl("https://creativecommons.org/licenses/by-nc/2.0/legalcode"));
+    assertNull(License.fromLicenseUrl("https://creativecommons.org/licenses/by-nc/2.0/"));
+  }
+}

--- a/src/test/java/org/gbif/api/vocabulary/MaintenanceUpdateFrequencyTest.java
+++ b/src/test/java/org/gbif/api/vocabulary/MaintenanceUpdateFrequencyTest.java
@@ -1,0 +1,21 @@
+package org.gbif.api.vocabulary;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MaintenanceUpdateFrequencyTest {
+
+  @Test
+  public void testFromString() throws Exception {
+    // with spaces
+    assertEquals(MaintenanceUpdateFrequency.AS_NEEDED, MaintenanceUpdateFrequency.fromString("asNeeded"));
+    assertEquals(MaintenanceUpdateFrequency.AS_NEEDED, MaintenanceUpdateFrequency.fromString("as needed"));
+    assertEquals(MaintenanceUpdateFrequency.AS_NEEDED, MaintenanceUpdateFrequency.fromString("as-needed"));
+    assertEquals(MaintenanceUpdateFrequency.AS_NEEDED, MaintenanceUpdateFrequency.fromString("ASNEEDED"));
+    assertEquals(MaintenanceUpdateFrequency.OTHER_MAINTENANCE_PERIOD, MaintenanceUpdateFrequency.fromString("otherMaintenancePeriod"));
+    assertEquals(MaintenanceUpdateFrequency.NOT_PLANNED, MaintenanceUpdateFrequency.fromString("notPlanned"));
+    // typo matches vocabulary
+    assertEquals(MaintenanceUpdateFrequency.UNKOWN, MaintenanceUpdateFrequency.fromString("unkown"));
+  }
+}


### PR DESCRIPTION
Implements the changes outlined in [POR-2562](http://dev.gbif.org/issues/browse/POR-2562). 

Worthy of special attention, is the addition of a License enumeration, used to add a license property to the Dataset object. The License enumeration is restricted to the 3 CC licenses that GBIF currently supports. GBIF will have to support newer versions of these licenses in the future when they become available. It is important that GBIF differentiate between license/waiver versions because there are significant changes between them. To start, however, GBIF's recommendation (based on CC's recommendation) is to only support the latest version of each license: CC0 v1.0, CC-BY v4.0, and CC-BY-NC v4.0

A free-text rights statement (Dataset.rights property) can still be provided by publishers not wanting to adopt a GBIF-supported license. Datasets without a GBIF-supported license will not be indexed, however, they may remain discoverable on http://www.gbif.org as metadata-only datasets.

_Not included in this pull request,_ but something we might like to add is a new property named projectIdentifier to the Dataset model object. This will enable searching datasets by project identifier, see [POR-3129](http://dev.gbif.org/issues/browse/POR-3129).

Thank you for everyone's review of the proposed set of changes and recommendation above.