### PR TITLE
Changes for #15 to get closer to building/testing with Java-9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <jts.version>1.13</jts.version>
     <junit.version>4.12</junit.version>
     <logback.version>1.1.3</logback.version>
-    <mockito.version>1.10.19</mockito.version>
+    <mockito.version>2.8.9</mockito.version>
     <slf4j.version>1.7.12</slf4j.version>
     <validation-api.version>1.1.0.Final</validation-api.version>
   </properties>


### PR DESCRIPTION
Unfortunately I was not able to get testing working with Java-9 due to an unknown issue with the way VocabularyUtils.listEnumerations is attempting to scan packages using the Guava ClassPath tool. It may be as simple as adding a ``--add-modules`` to bring the relevant test classes onto the classpath, but not sure where to start with that at this point in time.

I tried updating to Guava-22.0, which involved changing Objects.toStringHelper to MoreObjects.toStringHelper (why would you do that Google??), but that didn't fix the issue, so I haven't included those changes here, given the sensitivity of the Guava version across dependencies. The Java-9 changes for Guava are being tracked at: https://github.com/google/guava/issues/2571

I also added "--add-modules java.xml.bind" to surefire for all Java-9+ users in motherpom, tracked in its pull request. As with other cases, the motherpom version needs to be bumped to 38-SNAPSHOT to test this PR with Java-9.