### PR TITLE
Update OccurrenceIssue.java

### DIFF
--- a/src/main/java/org/gbif/api/vocabulary/OccurrenceIssue.java
+++ b/src/main/java/org/gbif/api/vocabulary/OccurrenceIssue.java
@@ -443,9 +443,6 @@ public enum OccurrenceIssue implements InterpretationRemark {
   AGE_OR_STAGE_RANK_MISMATCH(
       INFO, DwcTerm.earliestAgeOrLowestStage, DwcTerm.latestAgeOrHighestStage),
 
-  /** The earliest eon or eonothem has to be earlier than the latest. */
-  EON_OR_EONOTHEM_INVALID_RANGE(
-      INFO, DwcTerm.earliestEonOrLowestEonothem, DwcTerm.latestEonOrHighestEonothem),
   /** The era or erathem has to be earlier than the latest. */
   ERA_OR_ERATHEM_INVALID_RANGE(
       INFO, DwcTerm.earliestEraOrLowestErathem, DwcTerm.latestEraOrHighestErathem),


### PR DESCRIPTION
The highest level is currently Eon or Eonothem, so it can never be earlier than the latest. There might be a higher level introduced if the vocabulary is updated (suggested [here](https://github.com/gbif/tech-docs/issues/167)), and then the flag should be introduced. If we'd rather keep it ([undocumented for now](https://github.com/gbif/tech-docs/edit/main/en/data-use/modules/ROOT/pages/occurrence-issues-and-flags.adoc)) then please disregard this PR.